### PR TITLE
Cache reel images and icon heights for faster alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,9 @@
       }
       const clone = strip.cloneNode(true);
       strip.parentNode.appendChild(clone);
-      reels.push({ strip, clone, pos: 0, speed: speeds[i], spinning: false });
+      const imgs = strip.querySelectorAll("img");
+      const iconHeight = imgs[0].offsetHeight;
+      reels.push({ strip, clone, imgs, iconHeight, pos: 0, speed: speeds[i], spinning: false });
     });
 
     function animate() {
@@ -229,8 +231,8 @@
     }
 
     function alignToIcon(reel, targetURL) {
-      const imgs = reel.strip.querySelectorAll("img");
-      const iconHeight = imgs[0].offsetHeight;
+      const imgs = reel.imgs;
+      const iconHeight = reel.iconHeight;
       const centerOffset = reel.strip.offsetHeight / 2 - iconHeight / 2;
 
       for (let i = 10; i < imgs.length; i++) {

--- a/slot video/index.html
+++ b/slot video/index.html
@@ -206,7 +206,9 @@
       }
       const clone = strip.cloneNode(true);
       strip.parentNode.appendChild(clone);
-      reels.push({ strip, clone, pos: 0, speed: speeds[i], spinning: false });
+      const imgs = strip.querySelectorAll("img");
+      const iconHeight = imgs[0].offsetHeight;
+      reels.push({ strip, clone, imgs, iconHeight, pos: 0, speed: speeds[i], spinning: false });
     });
 
     function animate() {
@@ -229,8 +231,8 @@
     }
 
     function alignToIcon(reel, targetURL) {
-      const imgs = reel.strip.querySelectorAll("img");
-      const iconHeight = imgs[0].offsetHeight;
+      const imgs = reel.imgs;
+      const iconHeight = reel.iconHeight;
       const centerOffset = reel.strip.offsetHeight / 2 - iconHeight / 2;
 
       for (let i = 10; i < imgs.length; i++) {


### PR DESCRIPTION
## Summary
- Cache each reel's image nodes and icon height during initialization
- Align reels using cached image references to avoid repeated DOM queries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68943110aa88832fb73468beae7305c3