### PR TITLE
Scale reel icons and wrap images

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       justify-content: center;
     }
 
-    .strip-item img {
+    .strip img {
       width: 150%;
       height: 150%;
       object-fit: contain;
@@ -200,9 +200,12 @@
 
     strips.forEach((strip, i) => {
       for (let j = 0; j < 30; j++) {
+        const item = document.createElement("div");
+        item.className = "strip-item";
         const img = document.createElement("img");
         img.src = icons[j % icons.length];
-        strip.appendChild(img);
+        item.appendChild(img);
+        strip.appendChild(item);
       }
       const clone = strip.cloneNode(true);
       strip.parentNode.appendChild(clone);


### PR DESCRIPTION
## Summary
- Enlarge reel icons by applying 150% width/height styles to images in `.strip`
- Wrap generated images in `.strip-item` elements so existing layout styles apply

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689431befa88832f82d10af1c22857bf