### PR TITLE
Optimize DOM updates during strip setup

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,11 +39,13 @@ function selectIcons() {
 }
 
 strips.forEach((strip, i) => {
+  const fragment = document.createDocumentFragment();
   for (let j = 0; j < 30; j++) {
     const img = document.createElement("img");
     img.src = icons[j % icons.length];
-    strip.appendChild(img);
+    fragment.appendChild(img);
   }
+  strip.appendChild(fragment);
   const clone = strip.cloneNode(true);
   strip.parentNode.appendChild(clone);
   reels.push({ strip, clone, pos: 0, speed: speeds[i], spinning: false });


### PR DESCRIPTION
## Summary
- Build strip images using a `DocumentFragment` and append once to avoid repeated layout recalculations.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68943333de8c832f90ca9b3203c6c794