### PR TITLE
Cache reel height to avoid per-frame layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -44,9 +44,10 @@ strips.forEach((strip, i) => {
     img.src = icons[j % icons.length];
     strip.appendChild(img);
   }
+  const height = strip.scrollHeight;
   const clone = strip.cloneNode(true);
   strip.parentNode.appendChild(clone);
-  reels.push({ strip, clone, pos: 0, speed: speeds[i], spinning: false });
+  reels.push({ strip, clone, height, pos: 0, speed: speeds[i], spinning: false });
 });
 
 function animate() {
@@ -55,7 +56,7 @@ function animate() {
     if (!reel.spinning) return;
 
     reel.pos += reel.speed;
-    const scrollH = reel.strip.scrollHeight;
+    const scrollH = reel.height;
 
     if (reel.pos >= scrollH) reel.pos = 0;
 
@@ -78,7 +79,7 @@ function alignToIcon(reel, targetURL) {
       const offset = i * iconHeight;
       reel.pos = offset - centerOffset;
       reel.strip.style.transform = `translateY(${-reel.pos}px)`;
-      reel.clone.style.transform = `translateY(${-reel.pos + reel.strip.scrollHeight}px)`;
+      reel.clone.style.transform = `translateY(${-reel.pos + reel.height}px)`;
       break;
     }
   }


### PR DESCRIPTION
## Summary
- cache each reel's scroll height on setup
- use cached height during animation to prevent per-frame DOM reads
- leverage cached height when aligning clones

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_6894332b0e70832f960a48866e80a412