### PR TITLE
Reverse reel direction and enlarge icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -80,8 +80,8 @@ function animate() {
 
     if (reel.pos >= scrollH) reel.pos = 0;
 
-    reel.strip.style.transform = `translateY(${-reel.pos}px)`;
-    reel.clone.style.transform = `translateY(${-reel.pos + scrollH}px)`;
+    reel.strip.style.transform = `translateY(${reel.pos}px)`;
+    reel.clone.style.transform = `translateY(${reel.pos - scrollH}px)`;
 
     anySpinning = true;
   });
@@ -92,14 +92,15 @@ function animate() {
 function alignToIcon(reel, targetURL) {
   const imgs = reel.images;
   const iconHeight = reel.iconHeight;
-  const centerOffset = reel.strip.offsetHeight / 2 - iconHeight / 2;
+  const containerHeight = reel.strip.parentNode.offsetHeight;
+  const centerOffset = containerHeight / 2 - iconHeight / 2;
 
   for (let i = 10; i < imgs.length; i++) {
     if (imgs[i].src.includes(targetURL)) {
       const offset = i * iconHeight;
       reel.pos = offset - centerOffset;
-      reel.strip.style.transform = `translateY(${-reel.pos}px)`;
-      reel.clone.style.transform = `translateY(${-reel.pos + reel.height}px)`;
+      reel.strip.style.transform = `translateY(${reel.pos}px)`;
+      reel.clone.style.transform = `translateY(${reel.pos - reel.height}px)`;
       break;
     }
   }
@@ -116,6 +117,7 @@ function startSpin() {
     reel.spinning = true;
     reel.strip.classList.add('spinning');
     reel.clone.classList.add('spinning');
+    reel.clone.style.display = '';
   });
 
   animate();
@@ -127,6 +129,7 @@ function startSpin() {
       reels[i].strip.classList.remove('spinning');
       reels[i].clone.classList.remove('spinning');
       alignToIcon(reels[i], chosen[i]);
+      reels[i].clone.style.display = 'none';
 
       if (i === reels.length - 1) {
         cancelAnimationFrame(rafId);

--- a/style.css
+++ b/style.css
@@ -11,6 +11,9 @@
   width: 9.91%;
   height: 20.98%;
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #reel1-container { left: 32.06%; top: 24.73%; }
@@ -29,6 +32,7 @@
   width: 100%;
   display: flex;
   flex-direction: column;
+  align-items: center;
   transition: transform 1s ease-out;
 }
 
@@ -39,9 +43,9 @@
   justify-content: center;
 }
 
-.strip-item img {
-  width: 150%;
-  height: 150%;
+.strip img {
+  width: 200%;
+  height: 200%;
   object-fit: contain;
   filter: drop-shadow(0 2px 4px rgba(0,0,0,0.5));
 }


### PR DESCRIPTION
## Summary
- Make reels spin from top to bottom and only display one centered icon when they stop
- Double icon size and center content within each reel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689434c3a28c832faff915d1702ce4c8