### PR TITLE
Fix reel scrolling direction and container overflow

### DIFF
--- a/script.js
+++ b/script.js
@@ -80,8 +80,8 @@ function animate() {
 
     if (reel.pos >= scrollH) reel.pos = 0;
 
-    reel.strip.style.transform = `translateY(${reel.pos}px)`;
-    reel.clone.style.transform = `translateY(${reel.pos - scrollH}px)`;
+    reel.strip.style.transform = `translateY(${-reel.pos}px)`;
+    reel.clone.style.transform = `translateY(${-reel.pos + scrollH}px)`;
 
     anySpinning = true;
   });
@@ -99,8 +99,8 @@ function alignToIcon(reel, targetURL) {
     if (imgs[i].src.includes(targetURL)) {
       const offset = i * iconHeight;
       reel.pos = offset - centerOffset;
-      reel.strip.style.transform = `translateY(${reel.pos}px)`;
-      reel.clone.style.transform = `translateY(${reel.pos - reel.height}px)`;
+      reel.strip.style.transform = `translateY(${-reel.pos}px)`;
+      reel.clone.style.transform = `translateY(${-reel.pos + reel.height}px)`;
       break;
     }
   }

--- a/style.css
+++ b/style.css
@@ -22,7 +22,11 @@
 
 .reel {
   position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 
 .strip {


### PR DESCRIPTION
## Summary
- Make reel element fill its container and hide overflow
- Invert reel scroll direction to move upward with correct clone offset
- Apply inverted transform during alignment to maintain landing logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6894375d8440832f82663c0688153fc8