### PR TITLE
Disable strip transition during spin

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,6 +35,10 @@
   align-items: center;
   transition: transform 1s ease-out;
 }
+.strip.spinning {
+  transition: none;
+}
+
 
 .strip-item {
   height: 100%;


### PR DESCRIPTION
## Summary
- disable transition on `.strip` elements while spinning for instant response
- confirm existing JavaScript toggles the `spinning` class to restore transitions after spin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689437608f38832f8838b587eea3c499