### PR TITLE
Ensure slot icons fit within reels

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,8 +44,8 @@
 }
 
 .strip img {
-  width: 200%;
-  height: 200%;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   filter: drop-shadow(0 2px 4px rgba(0,0,0,0.5));
 }


### PR DESCRIPTION
## Summary
- Scale strip icons to fill reel containers without overflow

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "const iconHeight=1080*0.2098; const images=30; console.log('iconHeight', iconHeight); console.log('totalHeight', iconHeight*images);"`


------
https://chatgpt.com/codex/tasks/task_b_689437649240832f830e8a429a7ecc23