### PR TITLE
Fix reel position wrapping

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,7 +94,7 @@ function animate() {
     reel.pos += reel.speed;
     const scrollH = reel.height;
 
-    if (reel.pos >= scrollH) reel.pos = 0;
+    if (reel.pos >= scrollH) reel.pos -= scrollH;
 
     reel.strip.style.transform = `translateY(${-reel.pos}px)`;
     reel.clone.style.transform = `translateY(${-reel.pos + scrollH}px)`;


### PR DESCRIPTION
## Summary
- ensure reel position wraps smoothly instead of resetting

## Testing
- `node script.js` *(fails: document is not defined; requires browser)*

------
https://chatgpt.com/codex/tasks/task_b_6894e8c52044832f893d8b2fb7ba18ff