### PR TITLE
Remove reel gloss overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
       <div id="reel1" class="reel">
         <div class="strip"></div>
       </div>
-      <div class="reel-gloss"></div>
     </div>
 
     <!-- Reel 2 -->
@@ -21,7 +20,6 @@
       <div id="reel2" class="reel">
         <div class="strip"></div>
       </div>
-      <div class="reel-gloss"></div>
     </div>
 
     <!-- Reel 3 -->
@@ -29,7 +27,6 @@
       <div id="reel3" class="reel">
         <div class="strip"></div>
       </div>
-      <div class="reel-gloss"></div>
     </div>
 
     <!-- Handle -->

--- a/style.css
+++ b/style.css
@@ -62,22 +62,6 @@
   filter: blur(0.5px) brightness(1.2);
 }
 
-.reel-gloss {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  background: linear-gradient(to bottom,
-    rgba(0,0,0,0.3) 0%,
-    rgba(0,0,0,0) 20%,
-    rgba(0,0,0,0) 80%,
-    rgba(0,0,0,0.3) 100%);
-  border-radius: 50%;
-  z-index: 2;
-}
-
 .reel img {
   filter: brightness(1) saturate(0.9) sepia(0.1);
 }


### PR DESCRIPTION
## Summary
- remove `reel-gloss` elements and styles to eliminate oval shadows on reels

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6894eb406378832fae1b88ab9720ef31