### PR TITLE
feat: add glass overlay for slot icons

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,6 +16,42 @@
   justify-content: center;
 }
 
+.reel-container::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255,255,255,0.35) 0%, rgba(255,255,255,0.15) 40%, rgba(255,255,255,0) 60%),
+              url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAIElEQVQoU2NkYGA4z0AEYBxVSFUBCjBWVQxkGgG6RABmOQAAAABJRU5ErkJggg==");
+  background-size: 100% 100%, 4px 4px;
+  background-repeat: no-repeat, repeat;
+  backdrop-filter: blur(0.5px);
+  z-index: 2;
+  box-shadow: inset 0 0 3px rgba(255,255,255,0.4), inset 0 0 6px rgba(0,0,0,0.25);
+}
+
+.reel-container::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(120deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.4) 50%, rgba(255,255,255,0) 100%);
+  mix-blend-mode: screen;
+  animation: reel-glare 3s linear infinite;
+  z-index: 3;
+}
+
+@keyframes reel-glare {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(200%); }
+}
+
 #reel1-container { left: 32.06%; top: 24.73%; }
 #reel2-container { left: 44.6%; top: 24.73%; }
 #reel3-container { left: 57.2%; top: 24.85%; }
@@ -64,6 +100,7 @@
 
 .reel img {
   filter: brightness(1) saturate(0.9) sepia(0.1);
+  opacity: 0.95;
 }
 
 .handle {


### PR DESCRIPTION
## Summary
- add animated glare and subtle noise texture on reel icons for a more convincing glass cover
- apply backdrop-filter blur and moving highlight animation to amplify realism

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6894ec393930832fbc7f52c1c0de19c3